### PR TITLE
Add build constraint for aws-sdk and slop

### DIFF
--- a/ec2list.gemspec
+++ b/ec2list.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "aws_config"
-  spec.add_runtime_dependency "aws-sdk"
-  spec.add_runtime_dependency "slop"
+  spec.add_runtime_dependency "aws-sdk", "~> 1.0"
+  spec.add_runtime_dependency "slop", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Thank you for developing nice tool :smile: 

I tried to use this gem, but its `ec2list.gemspec` runtime dependency has been broken.

My Gemfile.lock is as follows:

```
$ bundle install --path vendor/bundle
$ cat Gemfile.lock
PATH
  remote: .
  specs:
    ec2list (0.0.3)
      aws-sdk
      aws_config
      slop

GEM
  remote: https://rubygems.org/
  specs:
    aws-sdk (2.2.3)
      aws-sdk-resources (= 2.2.3)
    aws-sdk-core (2.2.3)
      jmespath (~> 1.0)
    aws-sdk-resources (2.2.3)
      aws-sdk-core (= 2.2.3)
    aws_config (0.0.2)
    jmespath (1.1.3)
    rake (10.4.2)
    slop (4.2.1)

PLATFORMS
  ruby

DEPENDENCIES
  bundler (~> 1.5)
  ec2list!
  rake

BUNDLED WITH
   1.10.5
```

The error message is as follows:

```
$ bundle exec bin/ec2list
/Users/minamijoyo/work/github/ec2list/lib/ec2list/command.rb:48:in `load_profile': uninitialized constant Ec2list::Command::AWS (NameError)
        from /Users/minamijoyo/work/github/ec2list/lib/ec2list/command.rb:7:in `initialize'
        from bin/ec2list:7:in `new'
        from bin/ec2list:7:in `<main>'
```

After changing aws-sdk to v1:

```
$ bundle exec bin/ec2list
/Users/minamijoyo/work/github/ec2list/lib/ec2list/command.rb:37:in `block in build_options': undefined method `banner' for #<Ec2list::Command:0x007fa25b12d428> (NoMethodError)
        from /Users/minamijoyo/work/github/ec2list/vendor/bundle/ruby/2.1.0/gems/slop-4.2.1/lib/slop/options.rb:33:in `initialize'
        from /Users/minamijoyo/work/github/ec2list/vendor/bundle/ruby/2.1.0/gems/slop-4.2.1/lib/slop.rb:23:in `new'
        from /Users/minamijoyo/work/github/ec2list/vendor/bundle/ruby/2.1.0/gems/slop-4.2.1/lib/slop.rb:23:in `parse'
        from /Users/minamijoyo/work/github/ec2list/lib/ec2list/command.rb:36:in `build_options'
        from /Users/minamijoyo/work/github/ec2list/lib/ec2list/command.rb:6:in `initialize'
        from bin/ec2list:7:in `new'
        from bin/ec2list:7:in `<main>'
```

And also, after changing the slop to v3, it works fine.

It seems that this issue was caused by incompatible changes of aws-sdk (v1 -> v2) and slop (v3 -> v4).
So, I fixed the runtime dependency in `ec2list.gemspec` .
